### PR TITLE
Decode from JsonData ADT to Student ADT.

### DIFF
--- a/json/DataTypes/JsonData.roc
+++ b/json/DataTypes/JsonData.roc
@@ -1,0 +1,9 @@
+module [JsonData]
+
+JsonData : [
+    String Str,
+    Number U64,
+    Null,
+    Object (Dict Str JsonData),
+    Arr (List JsonData),
+]

--- a/json/DataTypes/Student.roc
+++ b/json/DataTypes/Student.roc
@@ -1,0 +1,11 @@
+module [Student, Module]
+ 
+Student : {
+    name : Str,
+    modules : List (Module)
+}
+
+Module : {
+    name : Str,
+    credits : U64
+}

--- a/json/DataTypes/StudentData.json
+++ b/json/DataTypes/StudentData.json
@@ -1,0 +1,26 @@
+{
+    "students": [
+        {
+            "name": "Amy",
+            "modules": [
+                {
+                    "name": "Physics 101",
+                    "credits": 100
+                },
+                {
+                    "name": "Maths 101",
+                    "credits": 200
+                }
+            ]
+        },
+        {
+            "name": "John",
+            "modules": [
+                {
+                    "name": "Maths 101",
+                    "credits": 200
+                }
+            ]
+        }
+    ]
+}

--- a/json/DataTypes/StudentHandler.roc
+++ b/json/DataTypes/StudentHandler.roc
@@ -1,0 +1,74 @@
+module [getListStudents]
+
+import JsonData exposing [JsonData]
+import Student exposing [Student, Module]
+
+JsonErrors : [
+    FieldNotFound Str,
+    ExpectedJsonObject Str,
+    ExpectedJsonArray Str,
+]
+
+getListStudents : JsonData -> Result (List Student) JsonErrors
+getListStudents = \json ->
+    when json is
+        Object obj ->
+            when Dict.get obj "students" is
+                Ok students -> checkStudentList students
+                _ -> Err (FieldNotFound "Expected field with name \"students\" in object")
+
+        _ -> Err (ExpectedJsonObject "Expected an Object")
+
+checkStudentList : JsonData -> Result (List Student) JsonErrors
+checkStudentList = \json ->
+    when json is
+        Arr students ->
+            List.mapTry (List.map students checkStudentObj) \x -> x
+
+        _ -> Err (ExpectedJsonArray "Expected an Array")
+
+checkStudentObj : JsonData -> Result Student JsonErrors
+checkStudentObj = \json ->
+    when json is
+        Object obj ->
+            when Dict.get obj "name" is
+                Ok (String name) ->
+                    when Dict.get obj "modules" is
+                        Ok modules ->
+                            when checkModulesList modules is
+                                Ok goodMods ->
+                                    Ok ({ name: name, modules: goodMods })
+
+                                Err e -> Err e
+
+                        _ -> Err (FieldNotFound "Expected field with name \"modules\" in object")
+
+                _ -> Err (FieldNotFound "Expected field with name \"name\" in object")
+
+        _ -> Err (ExpectedJsonObject "Expected an Object")
+
+checkModulesList : JsonData -> Result (List Module) JsonErrors
+checkModulesList = \json ->
+    when json is
+        Arr modules ->
+            List.mapTry (List.map modules checkModuleObj) \x -> x
+
+        _ -> Err (ExpectedJsonArray "Expected an Array")
+
+checkModuleObj : JsonData -> Result Module JsonErrors
+checkModuleObj = \json ->
+    when json is
+        Object obj ->
+            when Dict.get obj "name" is
+                Ok (String name) ->
+                    when Dict.get obj "credits" is
+                        Ok (Number credits) ->
+                            Ok ({ credits: credits, name: name })
+
+                        _ -> Err (FieldNotFound "Expected field with name \"credits\" in object")
+
+                _ -> Err (FieldNotFound "Expected field with name \"name\" in object")
+
+        _ -> Err (ExpectedJsonObject "Expected an Object")
+
+

--- a/json/DataTypes/main.roc
+++ b/json/DataTypes/main.roc
@@ -1,0 +1,5 @@
+package [
+    JsonData,
+    Student,
+    StudentHandler
+]{}

--- a/json/main.roc
+++ b/json/main.roc
@@ -1,0 +1,55 @@
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.10.0/vNe6s9hWzoTZtFmNkvEICPErI9ptji_ySjicO6CkucY.tar.br",
+    jd: "DataTypes/main.roc",
+}
+import "DataTypes/StudentData.json" as students : Str
+import pf.Stdout
+import pf.Task
+import jd.StudentHandler
+
+main =
+    Stdout.line! "$(students)"
+
+expect StudentHandler.getListStudents input == Ok expected
+# expected Student output
+expected = [
+    {
+        name: "Amy",
+        modules: [{ name: "Maths 101", credits: 200 }, { name: "Physics 101", credits: 100 }],
+    },
+    {
+        name: "John",
+        modules: [{ name: "Maths 101", credits: 200 }],
+    },
+]
+# JsonData representation for input
+input = Object (Dict.empty {} |> Dict.insert "students" (Arr [amyObj, johnObj]))
+amyObj =
+    Object
+        (
+            Dict.empty {}
+            |> Dict.insert "name" (String "Amy")
+            |> Dict.insert "modules" (amyMods)
+        )
+johnObj =
+    Object
+        (
+            Dict.empty {}
+            |> Dict.insert "name" (String "John")
+            |> Dict.insert "modules" (johnMod)
+        )
+amyMods = Arr ([mathsMod, physicsMod])
+johnMod = Arr ([mathsMod])
+
+mathsMod = Object
+    (
+        Dict.empty {}
+        |> Dict.insert "name" (String "Maths 101")
+        |> Dict.insert "credits" (Number 200)
+    )
+physicsMod = Object
+    (
+        Dict.empty {}
+        |> Dict.insert "name" (String "Physics 101")
+        |> Dict.insert "credits" (Number 100)
+    )


### PR DESCRIPTION
This PR is the first iteration of decoding from a JSON ADT scale model representation into a representation of the data I've defined. 

We have: 
- `JsonData` which is the bare bones Sum type. 
-`Student` which represents the JSON in `StudentData.json`

I have a few expectations in the `main.roc` to ensure we go from `JsonData` to `Student` correctly. 

https://dev.to/matthewsj/you-could-have-designed-the-jsondecode-library-2d8 This article was really helpful in showing me how to lay out a simple but verbose JSON decoder. 

The next steps are to take a lot of the boilerplate code and simplify it (mainly the error handling) and then build a story around this process. 
